### PR TITLE
switch to http access for mockapi

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -56,7 +56,7 @@ class TodoApp extends React.Component{
     this.state = {
       data: []
     }
-    this.apiUrl = 'https://57b1924b46b57d1100a3c3f8.mockapi.io/api/todos'
+    this.apiUrl = 'http://57b1924b46b57d1100a3c3f8.mockapi.io/api/todos'
   }
   // Lifecycle method
   componentDidMount(){


### PR DESCRIPTION
switching to http for the mockapi call since https generates certificate warnings.
fixes #1
you propably need to rebundle public/bundle.js
